### PR TITLE
Upgrade workmanagementproxy to Java 25 / WildFly 40 / Camunda 7.24

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -1,6 +1,6 @@
+# Java 25 / WildFly 40 upgrade (25.104.x)
 name: CPP Context Verify & Validation
 
-# Need to update this for actual migration
 trigger:
   branches:
     include:
@@ -21,12 +21,12 @@ resources:
       type: github
       name: hmcts/cpp-azure-devops-templates
       endpoint: 'hmcts'
-      ref: 'main'
+      ref: 'wildfly40'
 
 pool:
   name: "MDV-ADO-AGENT-AKS-01"
   demands:
-    - identifier -equals centos8-j17
+    - identifier -equals ubuntu-j25-postgres
 
 variables:
   sonarqubeProject: "uk.gov.moj.cpp.workmanagement.proxy:work-management-proxy-parent"
@@ -48,3 +48,4 @@ stages:
           serviceName: ${{ variables['service_Name'] }}
           itTestFolder: ${{ variables['itTest_Folder'] }}
           isCamunda: true
+          aksDeployBranch: 'wildfly40'

--- a/pom.xml
+++ b/pom.xml
@@ -6,13 +6,13 @@
     <parent>
         <groupId>uk.gov.moj.cpp.common</groupId>
         <artifactId>service-parent-pom</artifactId>
-        <version>17.104.0</version>
+        <version>25.104.0-M4</version>
     </parent>
 
 
     <groupId>uk.gov.moj.cpp.work-management-proxy</groupId>
     <artifactId>work-management-proxy-parent</artifactId>
-    <version>17.104.53-SNAPSHOT</version>
+    <version>25.104.0-M1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Work management proxy - Parent module</name>
@@ -23,13 +23,16 @@
         <sonar.scm.provider>git</sonar.scm.provider>
         <sonar.coverage.exclusions>**/model/*</sonar.coverage.exclusions>
         <sonar.cpd.exclusions>**/model/*</sonar.cpd.exclusions>
-        <cpp.camunda.version>7.17.0</cpp.camunda.version>
-        <org.mapstruct.version>1.5.5.Final</org.mapstruct.version>
+        <cpp.camunda.version>7.24.0</cpp.camunda.version>
+        <!-- JDK 25 needs newer lombok/mapstruct; the 25.104.0-M4 parent/common-bom still pin
+             lombok 1.18.26 + mapstruct 1.5.5 (fail on JDK 25 with TypeTag :: UNKNOWN). Override here
+             until the platform BOM bumps them. -->
+        <org.mapstruct.version>1.6.3</org.mapstruct.version>
         <lombok.mapstruct.binding.version>0.2.0</lombok.mapstruct.binding.version>
-        <org.projectlombok.version>1.18.26</org.projectlombok.version>
-        <usersgroups.version>17.104.49</usersgroups.version>
-        <referencedata.version>17.103.132</referencedata.version>
-        <coredomain.version>17.104.4</coredomain.version>
+        <org.projectlombok.version>1.18.40</org.projectlombok.version>
+        <usersgroups.version>17.104.50</usersgroups.version>
+        <referencedata.version>17.103.133</referencedata.version>
+        <coredomain.version>25.104.0-M4</coredomain.version>
         <jgitflow-maven-plugin.version>1.0-m5.1</jgitflow-maven-plugin.version>
     </properties>
 

--- a/work-management-proxy-api/pom.xml
+++ b/work-management-proxy-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.moj.cpp.work-management-proxy</groupId>
         <artifactId>work-management-proxy-parent</artifactId>
-        <version>17.104.53-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <artifactId>work-management-proxy-api</artifactId>
@@ -22,8 +22,8 @@
             <artifactId>commons-lang3</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-api</artifactId>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -31,8 +31,8 @@
             <artifactId>framework-api-domain</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.json</groupId>
-            <artifactId>javax.json-api</artifactId>
+            <groupId>jakarta.json</groupId>
+            <artifactId>jakarta.json-api</artifactId>
         </dependency>
         <dependency>
             <groupId>uk.gov.moj.cpp.common</groupId>
@@ -71,7 +71,7 @@
         <!-- provides a default EjbProcessApplication -->
         <dependency>
             <groupId>org.camunda.bpm.javaee</groupId>
-            <artifactId>camunda-ejb-client</artifactId>
+            <artifactId>camunda-ejb-client-jakarta</artifactId>
         </dependency>
         <dependency>
             <groupId>uk.gov.moj.cpp.work-management-proxy</groupId>
@@ -187,7 +187,7 @@
         <!-- camunda cdi beans -->
         <dependency>
             <groupId>org.camunda.bpm</groupId>
-            <artifactId>camunda-engine-cdi</artifactId>
+            <artifactId>camunda-engine-cdi-jakarta</artifactId>
         </dependency>
 
         <!-- provides a default EjbProcessApplication -->
@@ -268,9 +268,14 @@
                 <artifactId>rest-client-generator-plugin</artifactId>
                 <dependencies>
                     <dependency>
-                        <groupId>javax</groupId>
-                        <artifactId>javaee-api</artifactId>
+                        <groupId>jakarta.platform</groupId>
+                        <artifactId>jakarta.jakartaee-api</artifactId>
                         <version>${javaee-api.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>jakarta.xml.bind</groupId>
+                        <artifactId>jakarta.xml.bind-api</artifactId>
+                        <version>${jakarta.xml.bind-api.raml.version}</version>
                     </dependency>
                     <dependency>
                         <groupId>uk.gov.moj.cpp.usersgroups</groupId>

--- a/work-management-proxy-api/src/main/java/uk/gov/moj/cpp/workmanagement/proxy/api/CamundaProxyApi.java
+++ b/work-management-proxy-api/src/main/java/uk/gov/moj/cpp/workmanagement/proxy/api/CamundaProxyApi.java
@@ -52,10 +52,10 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
-import javax.inject.Inject;
-import javax.json.JsonArrayBuilder;
-import javax.json.JsonObject;
-import javax.json.JsonObjectBuilder;
+import jakarta.inject.Inject;
+import jakarta.json.JsonArrayBuilder;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/work-management-proxy-api/src/main/java/uk/gov/moj/cpp/workmanagement/proxy/api/CompleteTaskApi.java
+++ b/work-management-proxy-api/src/main/java/uk/gov/moj/cpp/workmanagement/proxy/api/CompleteTaskApi.java
@@ -15,7 +15,7 @@ import uk.gov.justice.services.core.annotation.Handles;
 import uk.gov.justice.services.messaging.JsonEnvelope;
 import uk.gov.moj.cpp.workmanagement.proxy.api.service.UserService;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import org.camunda.bpm.engine.ProcessEngine;
 import org.camunda.bpm.engine.RuntimeService;

--- a/work-management-proxy-api/src/main/java/uk/gov/moj/cpp/workmanagement/proxy/api/exception/ExceptionProvider.java
+++ b/work-management-proxy-api/src/main/java/uk/gov/moj/cpp/workmanagement/proxy/api/exception/ExceptionProvider.java
@@ -12,9 +12,9 @@ import uk.gov.moj.cpp.workmanagement.proxy.api.service.WorkManagementResponseBui
 
 import java.util.Optional;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
-import javax.ws.rs.core.Response;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.Response;
 
 import org.slf4j.Logger;
 

--- a/work-management-proxy-api/src/main/java/uk/gov/moj/cpp/workmanagement/proxy/api/interceptor/ProxyRestApiInterceptor.java
+++ b/work-management-proxy-api/src/main/java/uk/gov/moj/cpp/workmanagement/proxy/api/interceptor/ProxyRestApiInterceptor.java
@@ -17,10 +17,10 @@ import uk.gov.moj.cpp.workmanagement.proxy.api.service.WorkManagementResponseBui
 
 import java.util.List;
 
-import javax.inject.Inject;
-import javax.json.JsonValue;
-import javax.servlet.http.HttpServletRequest;
-import javax.ws.rs.core.Response;
+import jakarta.inject.Inject;
+import jakarta.json.JsonValue;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.core.Response;
 
 import org.apache.http.HttpStatus;
 import org.slf4j.Logger;

--- a/work-management-proxy-api/src/main/java/uk/gov/moj/cpp/workmanagement/proxy/api/service/CamundaJavaApiService.java
+++ b/work-management-proxy-api/src/main/java/uk/gov/moj/cpp/workmanagement/proxy/api/service/CamundaJavaApiService.java
@@ -67,9 +67,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
-import javax.json.JsonObject;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.json.JsonObject;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/work-management-proxy-api/src/main/java/uk/gov/moj/cpp/workmanagement/proxy/api/service/ReferenceDataService.java
+++ b/work-management-proxy-api/src/main/java/uk/gov/moj/cpp/workmanagement/proxy/api/service/ReferenceDataService.java
@@ -15,8 +15,8 @@ import uk.gov.moj.cpp.workmanagement.proxy.api.model.WorkflowTaskType;
 import java.util.List;
 import java.util.UUID;
 
-import javax.inject.Inject;
-import javax.json.JsonObject;
+import jakarta.inject.Inject;
+import jakarta.json.JsonObject;
 
 public class ReferenceDataService {
     private static final String REFERENCE_DATA_QUERY_WORKFLOW_TASK_TYPES = "referencedata.query.workflow-task-types";

--- a/work-management-proxy-api/src/main/java/uk/gov/moj/cpp/workmanagement/proxy/api/service/RestClientService.java
+++ b/work-management-proxy-api/src/main/java/uk/gov/moj/cpp/workmanagement/proxy/api/service/RestClientService.java
@@ -3,15 +3,15 @@ package uk.gov.moj.cpp.workmanagement.proxy.api.service;
 import org.jboss.resteasy.client.jaxrs.internal.ResteasyClientBuilderImpl;
 import uk.gov.justice.services.common.configuration.Value;
 
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import java.util.concurrent.TimeUnit;
 
 import static java.lang.Integer.parseInt;

--- a/work-management-proxy-api/src/main/java/uk/gov/moj/cpp/workmanagement/proxy/api/service/TaskFilterService.java
+++ b/work-management-proxy-api/src/main/java/uk/gov/moj/cpp/workmanagement/proxy/api/service/TaskFilterService.java
@@ -45,9 +45,9 @@ import java.time.ZoneId;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
-import javax.json.JsonObject;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.json.JsonObject;
 
 import org.camunda.bpm.engine.HistoryService;
 import org.camunda.bpm.engine.TaskService;

--- a/work-management-proxy-api/src/main/java/uk/gov/moj/cpp/workmanagement/proxy/api/service/UserService.java
+++ b/work-management-proxy-api/src/main/java/uk/gov/moj/cpp/workmanagement/proxy/api/service/UserService.java
@@ -10,8 +10,8 @@ import uk.gov.justice.services.messaging.Envelope;
 import uk.gov.justice.services.messaging.JsonEnvelope;
 import uk.gov.justice.services.messaging.MetadataBuilder;
 
-import javax.inject.Inject;
-import javax.json.JsonObject;
+import jakarta.inject.Inject;
+import jakarta.json.JsonObject;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/work-management-proxy-api/src/main/java/uk/gov/moj/cpp/workmanagement/proxy/api/service/WorkManagementResponseBuilder.java
+++ b/work-management-proxy-api/src/main/java/uk/gov/moj/cpp/workmanagement/proxy/api/service/WorkManagementResponseBuilder.java
@@ -9,12 +9,12 @@ import static uk.gov.moj.cpp.workmanagement.proxy.api.util.JsonUtils.isJsonValid
 import java.io.StringReader;
 import java.util.Optional;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.json.JsonArray;
-import javax.json.JsonReader;
-import javax.json.JsonStructure;
-import javax.json.JsonValue;
-import javax.ws.rs.core.Response;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonReader;
+import jakarta.json.JsonStructure;
+import jakarta.json.JsonValue;
+import jakarta.ws.rs.core.Response;
 
 import org.apache.http.HttpStatus;
 

--- a/work-management-proxy-api/src/main/java/uk/gov/moj/cpp/workmanagement/proxy/api/service/WorkflowTaskTypeMapper.java
+++ b/work-management-proxy-api/src/main/java/uk/gov/moj/cpp/workmanagement/proxy/api/service/WorkflowTaskTypeMapper.java
@@ -13,9 +13,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
 
-import javax.json.JsonArray;
-import javax.json.JsonObject;
-import javax.json.JsonValue;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;

--- a/work-management-proxy-api/src/main/resources/META-INF/beans.xml
+++ b/work-management-proxy-api/src/main/resources/META-INF/beans.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns="http://xmlns.jcp.org/xml/ns/javaee"
-       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
-       version="1.1" bean-discovery-mode="all">
+       xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+       version="4.0" bean-discovery-mode="all">
 </beans>

--- a/work-management-proxy-api/src/test/java/uk/gov/moj/cpp/workmanagement/proxy/api/CamundaProxyApiTest.java
+++ b/work-management-proxy-api/src/test/java/uk/gov/moj/cpp/workmanagement/proxy/api/CamundaProxyApiTest.java
@@ -77,10 +77,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import javax.json.JsonArray;
-import javax.json.JsonArrayBuilder;
-import javax.json.JsonObject;
-import javax.json.JsonObjectBuilder;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonArrayBuilder;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.camunda.bpm.engine.HistoryService;
@@ -999,12 +999,15 @@ public class CamundaProxyApiTest {
         taskId = taskOne.getId();
         final Task taskTwo = activeTasks.get(1);
 
+        // Camunda 7.24 enforces optimistic locking on saveTask more strictly: createComment bumps
+        // the task's DB revision, so saving the (now stale) in-memory task afterwards throws
+        // ENGINE-03005. Save the task first, then add the comment.
+        taskOne.setDueDate(dueDate);
+        taskService.saveTask(taskOne);
+
         if (hasTaskComment) {
             taskService.createComment(taskId, processInstanceId, TASK_ONE_COMMENT_VAL);
         }
-
-        taskOne.setDueDate(dueDate);
-        taskService.saveTask(taskOne);
 
         taskTwo.setDueDate(dueDate);
         taskService.saveTask(taskTwo);
@@ -1391,13 +1394,14 @@ public class CamundaProxyApiTest {
         taskId = taskOne.getId();
         final Task taskTwo = activeTasks.get(1);
 
+        // Camunda 7.24: save before createComment (which bumps the task revision) to avoid ENGINE-03005.
+        taskOne.setDueDate(dueDate);
+        taskService.saveTask(taskOne);
+
         if (hasTaskComment) {
             taskService.createComment(taskId, processInstanceId, TASK_ONE_COMMENT_VAL);
         }
 
-        taskOne.setDueDate(dueDate);
-
-        taskService.saveTask(taskOne);
         taskTwo.setDueDate(dueDate);
         taskService.saveTask(taskTwo);
         taskService.setAssignee(taskOne.getId(), "testAssignee1");

--- a/work-management-proxy-api/src/test/java/uk/gov/moj/cpp/workmanagement/proxy/api/CompleteTaskApiTest.java
+++ b/work-management-proxy-api/src/test/java/uk/gov/moj/cpp/workmanagement/proxy/api/CompleteTaskApiTest.java
@@ -27,8 +27,8 @@ import uk.gov.moj.cpp.workmanagement.proxy.api.service.UserService;
 import java.util.List;
 import java.util.UUID;
 
-import javax.json.JsonObject;
-import javax.json.JsonValue;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
 
 import org.camunda.bpm.engine.history.HistoricTaskInstance;
 import org.camunda.bpm.engine.history.HistoricVariableInstance;

--- a/work-management-proxy-api/src/test/java/uk/gov/moj/cpp/workmanagement/proxy/api/exception/ExceptionProviderTest.java
+++ b/work-management-proxy-api/src/test/java/uk/gov/moj/cpp/workmanagement/proxy/api/exception/ExceptionProviderTest.java
@@ -13,7 +13,7 @@ import uk.gov.justice.services.adapter.rest.exception.BadRequestException;
 import uk.gov.justice.services.common.exception.ForbiddenRequestException;
 import uk.gov.moj.cpp.workmanagement.proxy.api.service.WorkManagementResponseBuilder;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.BeforeEach;

--- a/work-management-proxy-api/src/test/java/uk/gov/moj/cpp/workmanagement/proxy/api/interceptor/ProxyRestApiInterceptorTest.java
+++ b/work-management-proxy-api/src/test/java/uk/gov/moj/cpp/workmanagement/proxy/api/interceptor/ProxyRestApiInterceptorTest.java
@@ -20,10 +20,10 @@ import uk.gov.moj.cpp.workmanagement.proxy.api.exception.ExceptionProvider;
 import uk.gov.moj.cpp.workmanagement.proxy.api.service.RestClientService;
 import uk.gov.moj.cpp.workmanagement.proxy.api.service.WorkManagementResponseBuilder;
 
-import javax.json.JsonObject;
-import javax.json.JsonValue;
-import javax.servlet.http.HttpServletRequest;
-import javax.ws.rs.core.Response;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.core.Response;
 
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.BeforeEach;

--- a/work-management-proxy-api/src/test/java/uk/gov/moj/cpp/workmanagement/proxy/api/service/CamundaJavaApiServiceTest.java
+++ b/work-management-proxy-api/src/test/java/uk/gov/moj/cpp/workmanagement/proxy/api/service/CamundaJavaApiServiceTest.java
@@ -80,7 +80,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-import javax.json.JsonObject;
+import jakarta.json.JsonObject;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.camunda.bpm.engine.HistoryService;

--- a/work-management-proxy-api/src/test/java/uk/gov/moj/cpp/workmanagement/proxy/api/service/ReferenceDataServiceTest.java
+++ b/work-management-proxy-api/src/test/java/uk/gov/moj/cpp/workmanagement/proxy/api/service/ReferenceDataServiceTest.java
@@ -19,7 +19,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
-import javax.json.JsonObject;
+import jakarta.json.JsonObject;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;

--- a/work-management-proxy-api/src/test/java/uk/gov/moj/cpp/workmanagement/proxy/api/service/RestClientServiceTest.java
+++ b/work-management-proxy-api/src/test/java/uk/gov/moj/cpp/workmanagement/proxy/api/service/RestClientServiceTest.java
@@ -1,18 +1,18 @@
 package uk.gov.moj.cpp.workmanagement.proxy.api.service;
 
-import static javax.ws.rs.core.Response.Status.OK;
+import static jakarta.ws.rs.core.Response.Status.OK;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.client.Invocation;
-import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.client.Invocation;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/work-management-proxy-api/src/test/java/uk/gov/moj/cpp/workmanagement/proxy/api/service/TaskFilterServiceTest.java
+++ b/work-management-proxy-api/src/test/java/uk/gov/moj/cpp/workmanagement/proxy/api/service/TaskFilterServiceTest.java
@@ -36,8 +36,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import javax.json.JsonObject;
-import javax.json.JsonObjectBuilder;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
 
 import org.camunda.bpm.engine.HistoryService;
 import org.camunda.bpm.engine.RuntimeService;

--- a/work-management-proxy-api/src/test/java/uk/gov/moj/cpp/workmanagement/proxy/api/service/UsersServiceTest.java
+++ b/work-management-proxy-api/src/test/java/uk/gov/moj/cpp/workmanagement/proxy/api/service/UsersServiceTest.java
@@ -14,7 +14,7 @@ import uk.gov.justice.services.core.requester.Requester;
 import uk.gov.justice.services.messaging.Envelope;
 import uk.gov.justice.services.messaging.JsonEnvelope;
 
-import javax.json.JsonObject;
+import jakarta.json.JsonObject;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/work-management-proxy-api/src/test/java/uk/gov/moj/cpp/workmanagement/proxy/api/service/WorkManagementResponseBuilderTest.java
+++ b/work-management-proxy-api/src/test/java/uk/gov/moj/cpp/workmanagement/proxy/api/service/WorkManagementResponseBuilderTest.java
@@ -6,8 +6,8 @@ import static org.mockito.Mockito.when;
 
 import java.util.Optional;
 
-import javax.json.JsonValue;
-import javax.ws.rs.core.Response;
+import jakarta.json.JsonValue;
+import jakarta.ws.rs.core.Response;
 
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Test;

--- a/work-management-proxy-api/src/test/java/uk/gov/moj/cpp/workmanagement/proxy/api/service/WorkflowTaskTypeMapperTest.java
+++ b/work-management-proxy-api/src/test/java/uk/gov/moj/cpp/workmanagement/proxy/api/service/WorkflowTaskTypeMapperTest.java
@@ -12,9 +12,9 @@ import uk.gov.moj.cpp.workmanagement.proxy.api.util.ContextConstants;
 
 import java.util.List;
 
-import javax.json.JsonArray;
-import javax.json.JsonObject;
-import javax.json.JsonValue;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/work-management-proxy-api/src/test/resources/camunda.cfg.xml
+++ b/work-management-proxy-api/src/test/resources/camunda.cfg.xml
@@ -18,6 +18,10 @@
         <!-- job executor configurations -->
         <property name="jobExecutorActivate" value="false"/>
 
+        <!-- Camunda 7.20+ enforces a non-null history TTL on every process definition (ENGINE-12018).
+             Provide an engine-wide default so existing models parse without per-model changes. -->
+        <property name="historyTimeToLive" value="P180D"/>
+
     </bean>
 
 </beans>

--- a/work-management-proxy-healthchecks/pom.xml
+++ b/work-management-proxy-healthchecks/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>work-management-proxy-parent</artifactId>
         <groupId>uk.gov.moj.cpp.work-management-proxy</groupId>
-        <version>17.104.53-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -12,8 +12,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-api</artifactId>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/work-management-proxy-healthchecks/src/main/java/uk/gov/moj/cpp/workmanagement/proxy/healthchecks/WorkManagementProxyIgnoredHealthcheckNamesProvider.java
+++ b/work-management-proxy-healthchecks/src/main/java/uk/gov/moj/cpp/workmanagement/proxy/healthchecks/WorkManagementProxyIgnoredHealthcheckNamesProvider.java
@@ -13,7 +13,7 @@ import uk.gov.justice.services.healthcheck.healthchecks.artemis.ArtemisHealthche
 
 import java.util.List;
 
-import javax.enterprise.inject.Specializes;
+import jakarta.enterprise.inject.Specializes;
 
 @Specializes
 public class WorkManagementProxyIgnoredHealthcheckNamesProvider extends DefaultIgnoredHealthcheckNamesProvider {

--- a/work-management-proxy-healthchecks/src/main/resources/META-INF/beans.xml
+++ b/work-management-proxy-healthchecks/src/main/resources/META-INF/beans.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
-       version="1.1" bean-discovery-mode="all">
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+       version="4.0" bean-discovery-mode="all">
 </beans>

--- a/work-management-proxy-integration-test/pom.xml
+++ b/work-management-proxy-integration-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.moj.cpp.work-management-proxy</groupId>
         <artifactId>work-management-proxy-parent</artifactId>
-        <version>17.104.53-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <artifactId>work-management-proxy-integration-test</artifactId>

--- a/work-management-proxy-integration-test/src/test/java/uk/gov/moj/cpp/workmanagement/proxy/api/CompleteTaskIT.java
+++ b/work-management-proxy-integration-test/src/test/java/uk/gov/moj/cpp/workmanagement/proxy/api/CompleteTaskIT.java
@@ -12,7 +12,7 @@ import static org.hamcrest.Matchers.is;
 import uk.gov.moj.cpp.workmanagement.proxy.api.helper.AbstractIT;
 import uk.gov.moj.cpp.workmanagement.proxy.api.helper.WireMockStubUtils;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 
 import org.junit.jupiter.api.Test;
 

--- a/work-management-proxy-integration-test/src/test/java/uk/gov/moj/cpp/workmanagement/proxy/api/WorkManagementProcessDefinitionIT.java
+++ b/work-management-proxy-integration-test/src/test/java/uk/gov/moj/cpp/workmanagement/proxy/api/WorkManagementProcessDefinitionIT.java
@@ -7,7 +7,7 @@ import static org.hamcrest.Matchers.is;
 import uk.gov.moj.cpp.workmanagement.proxy.api.helper.AbstractIT;
 import uk.gov.moj.cpp.workmanagement.proxy.api.helper.WireMockStubUtils;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;

--- a/work-management-proxy-integration-test/src/test/java/uk/gov/moj/cpp/workmanagement/proxy/api/WorkManagementTasksIT.java
+++ b/work-management-proxy-integration-test/src/test/java/uk/gov/moj/cpp/workmanagement/proxy/api/WorkManagementTasksIT.java
@@ -16,7 +16,7 @@ import static uk.gov.moj.cpp.workmanagement.proxy.api.helper.RestHelper.pollForR
 import uk.gov.moj.cpp.workmanagement.proxy.api.helper.AbstractIT;
 import uk.gov.moj.cpp.workmanagement.proxy.api.helper.WireMockStubUtils;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/work-management-proxy-integration-test/src/test/java/uk/gov/moj/cpp/workmanagement/proxy/api/WorkflowRequestPermissionIT.java
+++ b/work-management-proxy-integration-test/src/test/java/uk/gov/moj/cpp/workmanagement/proxy/api/WorkflowRequestPermissionIT.java
@@ -9,7 +9,7 @@ import static uk.gov.moj.cpp.workmanagement.proxy.api.helper.WireMockStubUtils.s
 
 import uk.gov.moj.cpp.workmanagement.proxy.api.helper.AbstractIT;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/work-management-proxy-integration-test/src/test/java/uk/gov/moj/cpp/workmanagement/proxy/api/helper/AbstractIT.java
+++ b/work-management-proxy-integration-test/src/test/java/uk/gov/moj/cpp/workmanagement/proxy/api/helper/AbstractIT.java
@@ -4,7 +4,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.configureFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.reset;
 import static java.lang.System.getProperty;
 import static java.util.UUID.randomUUID;
-import static javax.ws.rs.core.Response.Status.NO_CONTENT;
+import static jakarta.ws.rs.core.Response.Status.NO_CONTENT;
 import static org.slf4j.LoggerFactory.getLogger;
 import static uk.gov.justice.services.common.http.HeaderConstants.USER_ID;
 import static uk.gov.moj.cpp.workmanagement.proxy.api.helper.RestHelper.HOST;
@@ -21,9 +21,9 @@ import static uk.gov.moj.cpp.workmanagement.proxy.api.helper.WireMockStubUtils.s
 
 import java.util.UUID;
 
-import javax.ws.rs.core.MultivaluedHashMap;
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.slf4j.Logger;

--- a/work-management-proxy-integration-test/src/test/java/uk/gov/moj/cpp/workmanagement/proxy/api/helper/BpmRestApiHelper.java
+++ b/work-management-proxy-integration-test/src/test/java/uk/gov/moj/cpp/workmanagement/proxy/api/helper/BpmRestApiHelper.java
@@ -9,8 +9,8 @@ import static java.util.Objects.isNull;
 import static java.util.stream.Collectors.toList;
 import static uk.gov.justice.services.messaging.JsonObjects.createObjectBuilder;
 import static uk.gov.justice.services.messaging.JsonObjects.createReader;
-import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
-import static javax.ws.rs.core.Response.Status.OK;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static jakarta.ws.rs.core.Response.Status.OK;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.slf4j.LoggerFactory.getLogger;
 import static uk.gov.justice.services.test.utils.core.http.RequestParamsBuilder.requestParams;
@@ -30,11 +30,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-import javax.json.JsonArray;
-import javax.json.JsonObject;
-import javax.json.JsonReader;
-import javax.json.JsonValue;
-import javax.ws.rs.core.Response;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonReader;
+import jakarta.json.JsonValue;
+import jakarta.ws.rs.core.Response;
 
 import org.hamcrest.Matcher;
 import org.json.JSONObject;

--- a/work-management-proxy-integration-test/src/test/java/uk/gov/moj/cpp/workmanagement/proxy/api/helper/ReferenceDataStub.java
+++ b/work-management-proxy-integration-test/src/test/java/uk/gov/moj/cpp/workmanagement/proxy/api/helper/ReferenceDataStub.java
@@ -5,14 +5,14 @@ import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static java.util.UUID.randomUUID;
-import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.apache.http.HttpStatus.SC_OK;
 import static uk.gov.justice.services.messaging.JsonObjects.createReader;
 import static uk.gov.moj.cpp.workmanagement.proxy.api.helper.WiremockTestHelper.waitForStubToBeReady;
 
 import uk.gov.justice.service.wiremock.testutil.InternalEndpointMockUtils;
 
-import javax.json.JsonObject;
+import jakarta.json.JsonObject;
 
 public class ReferenceDataStub {
     public static void setupRefDataGetWorkQueue(final String resourceName, final String workQueueId) {

--- a/work-management-proxy-integration-test/src/test/java/uk/gov/moj/cpp/workmanagement/proxy/api/helper/RestClientService.java
+++ b/work-management-proxy-integration-test/src/test/java/uk/gov/moj/cpp/workmanagement/proxy/api/helper/RestClientService.java
@@ -3,10 +3,10 @@ package uk.gov.moj.cpp.workmanagement.proxy.api.helper;
 import uk.gov.justice.services.test.utils.core.rest.RestClient;
 import uk.gov.justice.services.test.utils.core.rest.ResteasyClientBuilderFactory;
 
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/work-management-proxy-integration-test/src/test/java/uk/gov/moj/cpp/workmanagement/proxy/api/helper/RestHelper.java
+++ b/work-management-proxy-integration-test/src/test/java/uk/gov/moj/cpp/workmanagement/proxy/api/helper/RestHelper.java
@@ -1,7 +1,7 @@
 package uk.gov.moj.cpp.workmanagement.proxy.api.helper;
 
 import static java.util.UUID.randomUUID;
-import static javax.ws.rs.core.Response.Status.OK;
+import static jakarta.ws.rs.core.Response.Status.OK;
 import static org.hamcrest.CoreMatchers.allOf;
 import static uk.gov.justice.services.common.http.HeaderConstants.USER_ID;
 import static uk.gov.justice.services.test.utils.core.http.RequestParamsBuilder.requestParams;

--- a/work-management-proxy-integration-test/src/test/java/uk/gov/moj/cpp/workmanagement/proxy/api/helper/WireMockStubUtils.java
+++ b/work-management-proxy-integration-test/src/test/java/uk/gov/moj/cpp/workmanagement/proxy/api/helper/WireMockStubUtils.java
@@ -11,9 +11,9 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
 import static java.nio.charset.Charset.defaultCharset;
 import static java.text.MessageFormat.format;
-import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
-import static javax.ws.rs.core.Response.Status.NO_CONTENT;
-import static javax.ws.rs.core.Response.Status.OK;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static jakarta.ws.rs.core.Response.Status.NO_CONTENT;
+import static jakarta.ws.rs.core.Response.Status.OK;
 import static org.apache.http.HttpHeaders.CONTENT_TYPE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsNull.notNullValue;
@@ -29,7 +29,7 @@ import com.github.tomakehurst.wiremock.admin.model.ListStubMappingsResult;
 import java.io.InputStream;
 import java.util.UUID;
 
-import javax.ws.rs.core.Response.Status;
+import jakarta.ws.rs.core.Response.Status;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
 import org.apache.commons.io.IOUtils;

--- a/work-management-proxy-integration-test/src/test/java/uk/gov/moj/cpp/workmanagement/proxy/api/helper/WiremockTestHelper.java
+++ b/work-management-proxy-integration-test/src/test/java/uk/gov/moj/cpp/workmanagement/proxy/api/helper/WiremockTestHelper.java
@@ -8,7 +8,7 @@ import uk.gov.justice.services.test.utils.core.http.RequestParams;
 
 import java.util.concurrent.TimeUnit;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 
 public class WiremockTestHelper {
     private static final String HOST = System.getProperty("INTEGRATION_HOST_KEY", "localhost");

--- a/work-management-proxy-ping-all/pom.xml
+++ b/work-management-proxy-ping-all/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>work-management-proxy-parent</artifactId>
         <groupId>uk.gov.moj.cpp.work-management-proxy</groupId>
-        <version>17.104.53-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -11,13 +11,13 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-api</artifactId>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/work-management-proxy-ping-all/src/main/java/uk/gov/moj/cpp/workmanagement/proxy/ping/CamundaContextPinger.java
+++ b/work-management-proxy-ping-all/src/main/java/uk/gov/moj/cpp/workmanagement/proxy/ping/CamundaContextPinger.java
@@ -8,7 +8,7 @@ import uk.gov.moj.cpp.workmanagement.proxy.ping.configuration.ContextPingLocatio
 import uk.gov.moj.cpp.workmanagement.proxy.ping.http.ContextHttpPingException;
 import uk.gov.moj.cpp.workmanagement.proxy.ping.http.HttpContextPingerClient;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import org.slf4j.Logger;
 

--- a/work-management-proxy-ping-all/src/main/java/uk/gov/moj/cpp/workmanagement/proxy/ping/CamundaPingServlet.java
+++ b/work-management-proxy-ping-all/src/main/java/uk/gov/moj/cpp/workmanagement/proxy/ping/CamundaPingServlet.java
@@ -5,11 +5,11 @@ import static org.apache.http.HttpStatus.SC_OK;
 import java.io.IOException;
 import java.io.PrintWriter;
 
-import javax.inject.Inject;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.inject.Inject;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 @WebServlet(
         name = "camundaPingServlet",

--- a/work-management-proxy-ping-all/src/main/java/uk/gov/moj/cpp/workmanagement/proxy/ping/camunda/CamundaHealthcheck.java
+++ b/work-management-proxy-ping-all/src/main/java/uk/gov/moj/cpp/workmanagement/proxy/ping/camunda/CamundaHealthcheck.java
@@ -1,6 +1,6 @@
 package uk.gov.moj.cpp.workmanagement.proxy.ping.camunda;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import org.camunda.bpm.engine.RuntimeService;
 import org.camunda.bpm.engine.runtime.ProcessInstanceQuery;

--- a/work-management-proxy-ping-all/src/main/java/uk/gov/moj/cpp/workmanagement/proxy/ping/configuration/CamundaContextPingerConfiguration.java
+++ b/work-management-proxy-ping-all/src/main/java/uk/gov/moj/cpp/workmanagement/proxy/ping/configuration/CamundaContextPingerConfiguration.java
@@ -2,7 +2,7 @@ package uk.gov.moj.cpp.workmanagement.proxy.ping.configuration;
 
 import uk.gov.justice.services.common.configuration.Value;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 
 public class CamundaContextPingerConfiguration {

--- a/work-management-proxy-ping-all/src/main/java/uk/gov/moj/cpp/workmanagement/proxy/ping/configuration/ContextPingLocationProvider.java
+++ b/work-management-proxy-ping-all/src/main/java/uk/gov/moj/cpp/workmanagement/proxy/ping/configuration/ContextPingLocationProvider.java
@@ -8,7 +8,7 @@ import static uk.gov.moj.cpp.workmanagement.proxy.ping.configuration.CamundaCont
 
 import java.util.List;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import org.slf4j.Logger;
 

--- a/work-management-proxy-ping-all/src/main/java/uk/gov/moj/cpp/workmanagement/proxy/ping/http/HttpContextPingerClient.java
+++ b/work-management-proxy-ping-all/src/main/java/uk/gov/moj/cpp/workmanagement/proxy/ping/http/HttpContextPingerClient.java
@@ -8,7 +8,7 @@ import uk.gov.moj.cpp.workmanagement.proxy.ping.configuration.ContextPingLocatio
 
 import java.io.IOException;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import org.apache.http.HttpEntity;
 import org.apache.http.StatusLine;

--- a/work-management-proxy-ping-all/src/main/resources/META-INF/beans.xml
+++ b/work-management-proxy-ping-all/src/main/resources/META-INF/beans.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns="http://xmlns.jcp.org/xml/ns/javaee"
-       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
-       version="1.1" bean-discovery-mode="all">
+       xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+       version="4.0" bean-discovery-mode="all">
 </beans>

--- a/work-management-proxy-ping-all/src/test/java/uk/gov/moj/cpp/workmanagement/proxy/ping/CamundaPingServletTest.java
+++ b/work-management-proxy-ping-all/src/test/java/uk/gov/moj/cpp/workmanagement/proxy/ping/CamundaPingServletTest.java
@@ -6,8 +6,8 @@ import static org.mockito.Mockito.when;
 
 import java.io.PrintWriter;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;


### PR DESCRIPTION
## What
Upgrades **cpp-context-work-management-proxy** (workmanagementproxy) to **Java 25 / WildFly 40 / Jakarta EE 11 / Camunda 7.24** — the third and final Camunda context, following the businessprocesses pilot + shared artifacts (camunda-baked WF40 image, camunda-liquibase 7.24).

## Key changes
- **Camunda 7.17 → 7.24**; integration deps → jakarta variants (`camunda-engine-cdi-jakarta`, `camunda-ejb-client-jakarta`); `camunda-engine` core unchanged (provided).
- **javax → jakarta** (EE only — `ws.rs/servlet/enterprise/inject/json/annotation`; `javax.sql` kept as Java SE); 3 `beans.xml` → Jakarta EE 4.0; `javaee-api` → `jakarta.jakartaee-api`; `javax.json-api` → `jakarta.json-api`; `javax.servlet-api` → `jakarta.servlet-api`; jaxb plugin dep added to the rest-client generator (RAML).
- Parent `service-parent-pom` → `25.104.0-M4`; project + 5 modules → `25.104.0-M1-SNAPSHOT`; `coredomain` → `25.104.0-M4`; `usersgroups` → `17.104.50`; `referencedata` → `17.103.133`.
- **lombok `1.18.26` → `1.18.40`, mapstruct `1.5.5` → `1.6.3`** — required for JDK 25 (`TypeTag :: UNKNOWN`); the 25.104.0-M4 parent/common-bom still pin the old versions, so overridden here (worth a platform-BOM bump for any JDK-25 context using lombok).
- **Tests:** `historyTimeToLive=P180D` in the embedded-engine `camunda.cfg.xml` (ENGINE-12018); `CamundaProxyApiTest` save-task-before-createComment to avoid Camunda 7.24 stricter optimistic locking (ENGINE-03005).
- **`azure-pipelines.yaml`** → WF40/JDK25 track: `ubuntu-j25-postgres` agent, templates `ref: wildfly40`, `aksDeployBranch: wildfly40`, `isCamunda: true`.

## Verification
Full `mvn clean install` reactor build **green** (5 modules, all unit tests) on JDK 25 with the enforcer on. Integration tests to follow on the shared WF40/Camunda 7.24 stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
