### PR TITLE
Build the Camunda 7.24 schema: camunda-liquibase 17.21.4 -> 25.104.0-M1

### DIFF
--- a/docker/Dockerfile_workmanagementproxy-service
+++ b/docker/Dockerfile_workmanagementproxy-service
@@ -4,7 +4,7 @@ FROM ${baseImageUri}:${baseImageTag}
 
 ARG version
 ARG mavenArtifactBaseUrl
-ARG camunda_liquibase_version=17.21.4
+ARG camunda_liquibase_version=25.104.0-M1
 ARG wildfly_home=/opt/jboss/wildfly
 ARG wildfly_user=jboss
 ARG context_group_name=work-management-proxy


### PR DESCRIPTION
The workmanagementproxy-service image runs `camunda-liquibase.jar ... update` against the shared **workmanagement** (Camunda engine) database. `docker/Dockerfile_workmanagementproxy-service` pinned `camunda_liquibase_version=17.21.4` — a **Camunda 7.17** schema. Under the 7.24 engine the job executor cannot run timer jobs, so integration tests time out (e.g. `SJPTriggersDeleteDocumentsTest` — the delete-financial-means timer never fires).

**Fix:** bump to `25.104.0-M1`, which carries the full 7.17→7.24 changelog chain and builds the correct **7.24** schema (this is the same artifact/version our local Docker IT stack uses and passes on).

Merging this re-fires the release/validation build with the corrected schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)