### PR TITLE
Bump service-parent-pom M4 -> M7 (version 25.104.0-M3-SNAPSHOT)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,13 +7,13 @@
     <parent>
         <groupId>uk.gov.moj.cpp.common</groupId>
         <artifactId>service-parent-pom</artifactId>
-        <version>25.104.0-M4</version>
+        <version>25.104.0-M7</version>
     </parent>
 
 
     <groupId>uk.gov.moj.cpp.work-management-proxy</groupId>
     <artifactId>work-management-proxy-parent</artifactId>
-    <version>25.104.2-M2-SNAPSHOT</version>
+    <version>25.104.0-M3-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Work management proxy - Parent module</name>
@@ -33,7 +33,7 @@
         <org.projectlombok.version>1.18.40</org.projectlombok.version>
         <usersgroups.version>17.104.50</usersgroups.version>
         <referencedata.version>17.103.133</referencedata.version>
-        <coredomain.version>25.104.0-M4</coredomain.version>
+        <coredomain.version>25.104.0-M7</coredomain.version>
         <jgitflow-maven-plugin.version>1.0-m5.1</jgitflow-maven-plugin.version>
     </properties>
 

--- a/work-management-proxy-api/pom.xml
+++ b/work-management-proxy-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.moj.cpp.work-management-proxy</groupId>
         <artifactId>work-management-proxy-parent</artifactId>
-        <version>25.104.2-M2-SNAPSHOT</version>
+        <version>25.104.0-M3-SNAPSHOT</version>
     </parent>
 
     <artifactId>work-management-proxy-api</artifactId>

--- a/work-management-proxy-healthchecks/pom.xml
+++ b/work-management-proxy-healthchecks/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>work-management-proxy-parent</artifactId>
         <groupId>uk.gov.moj.cpp.work-management-proxy</groupId>
-        <version>25.104.2-M2-SNAPSHOT</version>
+        <version>25.104.0-M3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/work-management-proxy-integration-test/pom.xml
+++ b/work-management-proxy-integration-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.moj.cpp.work-management-proxy</groupId>
         <artifactId>work-management-proxy-parent</artifactId>
-        <version>25.104.2-M2-SNAPSHOT</version>
+        <version>25.104.0-M3-SNAPSHOT</version>
     </parent>
 
     <artifactId>work-management-proxy-integration-test</artifactId>

--- a/work-management-proxy-ping-all/pom.xml
+++ b/work-management-proxy-ping-all/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>work-management-proxy-parent</artifactId>
         <groupId>uk.gov.moj.cpp.work-management-proxy</groupId>
-        <version>25.104.2-M2-SNAPSHOT</version>
+        <version>25.104.0-M3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
Bumps work-management-proxy (Camunda) onto the latest released framework service-parent-pom.

## Changes
- `service-parent-pom` `25.104.0-M4` -> **`25.104.0-M7`** (pulls platform-libraries M8 + core-domain M7 transitively)
- `coredomain.version` `25.104.0-M4` -> **`25.104.0-M7`**
- project version `25.104.2-M2-SNAPSHOT` -> **`25.104.0-M3-SNAPSHOT`** (M2 already released; third digit always 0, milestone = latest-released + 1)

No stale MoJ interface versions flagged. The existing lombok/mapstruct overrides are left in place. Framework/version bump only.

## Verification
`rit` **GREEN** on WildFly 40 / JDK 25 / Camunda 7.24:
- RESULT: 1/1 war came back with pong
- 0 rollbacks
- unit suites pass; integration-test module 13/13, 0 failures/errors
- BUILD SUCCESS