### PR TITLE
Bump service-parent-pom M7 -> M9 (latest platform milestone)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>uk.gov.moj.cpp.common</groupId>
         <artifactId>service-parent-pom</artifactId>
-        <version>25.104.0-M7</version>
+        <version>25.104.0-M9</version>
     </parent>
 
 
@@ -33,7 +33,7 @@
         <org.projectlombok.version>1.18.40</org.projectlombok.version>
         <usersgroups.version>17.104.50</usersgroups.version>
         <referencedata.version>17.103.133</referencedata.version>
-        <coredomain.version>25.104.0-M7</coredomain.version>
+        <coredomain.version>25.104.0-M10</coredomain.version>
         <jgitflow-maven-plugin.version>1.0-m5.1</jgitflow-maven-plugin.version>
     </properties>
 


### PR DESCRIPTION
## What

Bump the parent `service-parent-pom` `25.104.0-M7` -> `25.104.0-M9` and `coredomain.version` `M7` -> `M9`.

## Why

Newer platform milestones were released (service-parent-pom M9, core-domain M9, carrying the Elasticsearch 9.3.3 chain); work-management-proxy was still on M7. Tidy-up alignment onto the current released platform; no functional change.

## Testing

- Full reactor build green (`mm`).
- Integration tests green on WildFly 40 / JDK 25 / Camunda 7.24: **13/13, 0 failures/errors**.

Code-only version bump.