### PR TITLE
Bump service-parent-pom M10 + coredomain M11 (Artemis 2.54)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>uk.gov.moj.cpp.common</groupId>
         <artifactId>service-parent-pom</artifactId>
-        <version>25.104.0-M9</version>
+        <version>25.104.0-M10</version>
     </parent>
 
 
@@ -33,7 +33,7 @@
         <org.projectlombok.version>1.18.40</org.projectlombok.version>
         <usersgroups.version>17.104.50</usersgroups.version>
         <referencedata.version>17.103.133</referencedata.version>
-        <coredomain.version>25.104.0-M10</coredomain.version>
+        <coredomain.version>25.104.0-M11</coredomain.version>
         <jgitflow-maven-plugin.version>1.0-m5.1</jgitflow-maven-plugin.version>
     </properties>
 


### PR DESCRIPTION
Bumps `service-parent-pom` `25.104.0-M9` → `25.104.0-M10` (Apache Artemis client `2.53.0` → `2.54.0` via common-bom M7) and `coredomain` `25.104.0-M10` → `25.104.0-M11`, keeping the 25.104.x set consistent with the Java-17 line / production Artemis 2.54 upgrade. Full build green (no enforcer skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)