### PR TITLE
Bump milestone version to 25.104.2-M4-SNAPSHOT (re-trigger release + docker image)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ buildContexts.sh
 lightning-jenkins.properties
 **/.DS_Store
 
+# Maven Shade plugin generated artifact
+dependency-reduced-pom.xml
+

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>uk.gov.moj.cpp.work-management-proxy</groupId>
     <artifactId>work-management-proxy-parent</artifactId>
-    <version>25.104.2-M3-SNAPSHOT</version>
+    <version>25.104.2-M4-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Work management proxy - Parent module</name>

--- a/work-management-proxy-api/pom.xml
+++ b/work-management-proxy-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.moj.cpp.work-management-proxy</groupId>
         <artifactId>work-management-proxy-parent</artifactId>
-        <version>25.104.2-M3-SNAPSHOT</version>
+        <version>25.104.2-M4-SNAPSHOT</version>
     </parent>
 
     <artifactId>work-management-proxy-api</artifactId>

--- a/work-management-proxy-healthchecks/pom.xml
+++ b/work-management-proxy-healthchecks/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>work-management-proxy-parent</artifactId>
         <groupId>uk.gov.moj.cpp.work-management-proxy</groupId>
-        <version>25.104.2-M3-SNAPSHOT</version>
+        <version>25.104.2-M4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/work-management-proxy-integration-test/pom.xml
+++ b/work-management-proxy-integration-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.moj.cpp.work-management-proxy</groupId>
         <artifactId>work-management-proxy-parent</artifactId>
-        <version>25.104.2-M3-SNAPSHOT</version>
+        <version>25.104.2-M4-SNAPSHOT</version>
     </parent>
 
     <artifactId>work-management-proxy-integration-test</artifactId>

--- a/work-management-proxy-ping-all/pom.xml
+++ b/work-management-proxy-ping-all/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>work-management-proxy-parent</artifactId>
         <groupId>uk.gov.moj.cpp.work-management-proxy</groupId>
-        <version>25.104.2-M3-SNAPSHOT</version>
+        <version>25.104.2-M4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
Bumps the project milestone version one step (`-M3` → `-M4`) across all modules to produce a real diff. The ADO release pipeline gates the artifact rebuild + ACR docker-image build on `shouldRebuildArtifacts`, which an empty commit does not set. This milestone bump forces it. Full build green with `-U` (no enforcer skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)